### PR TITLE
fix: Standardize template state management to resolve UI inconsistencies

### DIFF
--- a/src/stores/user_config.ts
+++ b/src/stores/user_config.ts
@@ -293,15 +293,6 @@ export const useUserConfigStore = defineStore('userConfig', () => {
         // 保存配置
         await saveConfig()
 
-        // 更新本地状态
-        const userTemplate = userTemplates.value.find(ut => ut.user.uid === userUid)
-        if (userTemplate) {
-            userTemplate.templates.push({
-                name: templateName,
-                config: userConfig.templates[templateName]
-            })
-        }
-
         return true
     }
 
@@ -335,15 +326,6 @@ export const useUserConfigStore = defineStore('userConfig', () => {
 
         // 保存配置
         await saveConfig()
-
-        // 更新本地状态
-        const userTemplate = userTemplates.value.find(ut => ut.user.uid === userUid)
-        if (userTemplate) {
-            const templateIndex = userTemplate.templates.findIndex(t => t.name === templateName)
-            if (templateIndex !== -1) {
-                userTemplate.templates.splice(templateIndex, 1)
-            }
-        }
 
         return true
     }
@@ -383,15 +365,6 @@ export const useUserConfigStore = defineStore('userConfig', () => {
 
         // 保存配置
         await saveConfig()
-
-        // 更新本地状态
-        const userTemplate = userTemplates.value.find(ut => ut.user.uid === userUid)
-        if (userTemplate) {
-            const template = userTemplate.templates.find(t => t.name === templateName)
-            if (template) {
-                template.config = userConfig.templates[templateName]
-            }
-        }
 
         return true
     }


### PR DESCRIPTION
- Remove manual modification of derived state `userTemplates`. 
- Ensure all add, delete, and modify operations for templates are performed solely by modifying the source state `configRoot`. 
- Rely on Vue's computed properties to automatically update the UI, resolving the bug of duplicate items appearing when creating templates. 

Close #14