### PR TITLE
fix: fix devtools console error

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,6 +9,7 @@
     "core:path:default",
     "core:event:default",
     "core:window:default",
+    "core:webview:default",
     "core:app:default",
     "core:image:default",
     "core:resources:default",


### PR DESCRIPTION
```
Uncaught (in promise) webview.internal_toggle_devtools not allowed. Permissions associated with this command: core:webview:allow-internal-toggle-devtools, core:webview:default
```